### PR TITLE
User cards updated

### DIFF
--- a/CRAB/crab_miniaod_generator.py
+++ b/CRAB/crab_miniaod_generator.py
@@ -1,0 +1,29 @@
+from WMCore.Configuration import Configuration  
+config = Configuration()  
+
+config.section_("General")  
+config.General.requestName = 'BuTau3Mu_bjoshi_CRAB3_MC2018_BuTau3Mu_13TeV_DIGI_87600497c2c6a5767aee5d92666e59c3_USER'
+config.General.workArea =  'MIANIAOD_Generation_15_12_20' 
+config.General.transferLogs = True 
+
+config.section_("JobType") 
+config.JobType.allowUndistributedCMSSW = True 
+config.JobType.pluginName = 'Analysis' 
+config.JobType.psetName = 'miniAOD-prod_PAT.py'  
+
+config.section_("Data")  
+
+config.Data.inputDataset = '/BuTau3Mu/bjoshi-CRAB3_MC2018_BuTau3Mu_13TeV_DIGI-87600497c2c6a5767aee5d92666e59c3/USER' 
+config.Data.inputDBS  = 'phys03' 
+config.Data.splitting = 'FileBased' 
+config.Data.unitsPerJob = 1 
+config.Data.totalUnits = -1 
+#config.Data.lumiMask = 'Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt' 
+config.Data.publication = True 
+config.Data.outLFNDirBase = '/store/user/bjoshi' 
+config.Data.outputDatasetTag = '' 
+
+config.section_("Site") 
+#config.Site.whitelist = ['T2_US_Wisconsin','T2_US_Purdue','T1_US_FNAL'] 
+#config.Data.ignoreLocality = True 
+config.Site.storageSite = 'T2_US_Florida' 

--- a/CRAB/inputFiles/UserCards/2017_Production_Dec_20_Bhargav.card
+++ b/CRAB/inputFiles/UserCards/2017_Production_Dec_20_Bhargav.card
@@ -1,0 +1,24 @@
+DataMCType: data
+Path: /DoubleMuonLowMass/Run2017B-09Aug2019_UL2017-v1/MINIAOD
+GT: 102X_dataRun2_v13
+Prod: global
+
+DataMCType: data
+Path: /DoubleMuonLowMass/Run2017C-09Aug2019_UL2017-v1/MINIAOD
+GT: 102X_dataRun2_v13
+Prod: global
+
+DataMCType: data
+Path: /DoubleMuonLowMass/Run2017D-09Aug2019_UL2017-v1/MINIAOD
+GT: 102X_dataRun2_v13
+Prod: global
+
+DataMCType: data
+Path: /DoubleMuonLowMass/Run2017E-09Aug2019_UL2017-v1/MINIAOD
+GT: 102X_dataRun2_v13
+Prod: global
+
+DataMCType: data
+Path: /DoubleMuonLowMass/Run2017F-09Aug2019_UL2017-v1/MINIAOD
+GT: 102X_dataRun2_v13
+Prod: global

--- a/CRAB/inputFiles/UserCards/2017_Production_MuonId_MINIAOD.card
+++ b/CRAB/inputFiles/UserCards/2017_Production_MuonId_MINIAOD.card
@@ -1,0 +1,40 @@
+DataMCTypes: minbias
+Path: /BsToPiPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_N1_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BsToKK_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BsToKK_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BdToKPi_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BdToKPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BdToKK_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global
+
+
+DataMCTypes: minbias
+Path: /BdToPiPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+GT: 102X_mc2017_realistic_v8
+Prod:  global

--- a/CRAB/inputFiles/UserCards/2018_Production_Dec_20_MINIAOD.card
+++ b/CRAB/inputFiles/UserCards/2018_Production_Dec_20_MINIAOD.card
@@ -1,0 +1,19 @@
+DataMCTypes: ds_tau
+Path: /DsToTau_TauMass1p87/wangjian-RunIIAutumn18MiniAOD-102X-c64c34953e011388ee7948c74fdb7fa0/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+DataMCTypes: ds_tau
+Path: /DsToTau_TauMass1p67/wangjian-RunIIAutumn18MiniAOD-102X-c64c34953e011388ee7948c74fdb7fa0/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+DataMCTypes: ds_tau
+Path: /DsToTau_TauTo3Mu_November2020/wangjian-RunIIAutumn18MiniAOD-102X-c64c34953e011388ee7948c74fdb7fa0/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+DataMCTypes: bp_tau
+Path: /BpToTau_TauTo3Mu_November2020/wangjian-RunIIAutumn18MiniAOD-102X-c64c34953e011388ee7948c74fdb7fa0/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03

--- a/CRAB/inputFiles/UserCards/2018_Production_MuonId_AOD.card
+++ b/CRAB/inputFiles/UserCards/2018_Production_MuonId_AOD.card
@@ -1,0 +1,46 @@
+DataMCTypes: minbias
+Path: /BsToPiPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BsToKK_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BsToKK_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BdToKPi_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BdToKPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BdToKK_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /BdToPiPi_BMuonFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: minbias
+Path: /MinBias_TuneCP5_13TeV-pythia8/RunIIAutumn18RECOBParking-PUPoissonAve20_BParking_102X_upgrade2018_realistic_v15-v2/AODSIM
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03

--- a/CRAB/inputFiles/UserCards/2018_Production_Nov_20_MINIAODs.card
+++ b/CRAB/inputFiles/UserCards/2018_Production_Nov_20_MINIAODs.card
@@ -1,0 +1,23 @@
+DataMCTypes: ds_tau
+Path: /DsToTau_TauTo3Mu_March2020/wangjian-RunIIAutumn18DRPremix-102X-2f1667a4ab974bdf4cb2916f291c3603/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod: phys03
+
+
+DataMCTypes: b0_tau
+Path: /B0ToTau_TauTo3Mu/wangjian-CRAB3_RunIIAutumn18DR_AODSIM-87600497c2c6a5767aee5d92666e59c3/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod:  phys03
+
+
+DataMCTypes: bp_tau
+Path: /BuTau3Mu/bjoshi-CRAB3_MC2018_BuTau3Mu_13TeV_DIGI-87600497c2c6a5767aee5d92666e59c3/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod:  phys03
+
+
+DataMCTypes: ds_phipi
+Path: /DsToPhiMuMuPi_CMSSW_10_2_X_2018/rosma-DsToPhiMuMuPi_CMSSW_10_2_X_2018_RECO_v1-fd6b33a813d01b1040d615bf889c29c4/USER
+GT: 102X_upgrade2018_realistic_v21
+Prod:  phys03
+

--- a/CRAB/runNtuple_template_miniaod.py
+++ b/CRAB/runNtuple_template_miniaod.py
@@ -100,9 +100,9 @@ process.TFileService = cms.Service('TFileService',
 
 process.source.fileNames = ['/store/data/Run2018D/DoubleMuonLowMass/MINIAOD/PromptReco-v2/000/325/159/00000/1403B072-371A-764C-9B25-A172D8B1A884.root'] #data
 #process.source.fileNames = [''] #minbias
-#process.source.fileNames = [''] #ds_tau
+#process.source.fileNames = ['/store/user/wangjian/DsToTau_TauTo3Mu_November2020/RunIIAutumn18MiniAOD-102X/201107_171229/0000/BPH-RunIIAutumn18MiniAOD-00158_144.root'] #ds_tau
 #process.source.fileNames = [''] #bd_tau
-#process.source.fileNames = [''] #bu_tau
+#process.source.fileNames = ['/store/user/wangjian/BpToTau_TauTo3Mu_November2020/RunIIAutumn18MiniAOD-102X/201112_084651/0000/BPH-RunIIAutumn18MiniAOD-00158_339.root'] #bu_tau
 #process.source.fileNames = ['/store/mc/RunIIFall17MiniAODv2/DsToPhiPi_ToMuMu_MuFilter_TuneCUEP8M1_13TeV-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/50000/76D80325-41C0-E911-9905-AC1F6BAC7C0A.root'] #ds_phipi
 
 ####################### TauNtuple (MINIAOD version) ######################


### PR DESCRIPTION
Few changes:

- User cards updated to include 2017UL datasets and B->KX/PiX decays samples (MuonId/Segment compatibility)
- script added to produce MiniAOD from AOD